### PR TITLE
Fix mongodb deprecation warning and reuse MongoClient

### DIFF
--- a/middlewares/database.js
+++ b/middlewares/database.js
@@ -5,6 +5,8 @@ const client = new MongoClient(process.env.MONGODB_URI, {
   useUnifiedTopology: true,
 });
 
+export { client };
+
 export default function database(req, res, next) {
   if (!client.isConnected()) {
     return client.connect().then(() => {

--- a/middlewares/database.js
+++ b/middlewares/database.js
@@ -1,6 +1,9 @@
 import { MongoClient } from 'mongodb';
 
-const client = new MongoClient(process.env.MONGODB_URI, { useNewUrlParser: true });
+const client = new MongoClient(process.env.MONGODB_URI, {
+  useNewUrlParser: true,
+  useUnifiedTopology: true,
+});
 
 export default function database(req, res, next) {
   if (!client.isConnected()) {

--- a/middlewares/database.js
+++ b/middlewares/database.js
@@ -5,15 +5,15 @@ const client = new MongoClient(process.env.MONGODB_URI, {
   useUnifiedTopology: true,
 });
 
-export { client };
-
 export default function database(req, res, next) {
   if (!client.isConnected()) {
     return client.connect().then(() => {
+      req.dbClient = client;
       req.db = client.db('nextjsmongodbapp');
       return next();
     });
   }
+  req.dbClient = client;
   req.db = client.db('nextjsmongodbapp');
   return next();
 }

--- a/middlewares/session.js
+++ b/middlewares/session.js
@@ -1,7 +1,8 @@
 import session from 'next-session';
 import connectMongo from 'connect-mongo';
-import { client } from './database';
 
 const MongoStore = connectMongo(session);
 
-export default session({ store: new MongoStore({ client }) });
+export default function (req, res, next) {
+  return session({ store: new MongoStore({ client: req.dbClient }) })(req, res, next);
+}

--- a/middlewares/session.js
+++ b/middlewares/session.js
@@ -1,6 +1,7 @@
 import session from 'next-session';
 import connectMongo from 'connect-mongo';
+import { client } from './database';
 
 const MongoStore = connectMongo(session);
 
-export default session({ store: new MongoStore({ url: process.env.MONGODB_URI }) });
+export default session({ store: new MongoStore({ client }) });

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "mongodb": "^3.3.0-beta2",
     "next": "^9.0.4-canary.2",
     "next-connect": "^0.4.0",
-    "next-session": "^2.1.0",
+    "next-session": "^2.1.1",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "validator": "^12.0.0"


### PR DESCRIPTION
This PR reuse MongoClient for `connect-mongo` so that there is no need for two seperate db connection. In addition, this fix deprecation warning in `mongodb` and `next-session`.