### PR TITLE
Fix Passport authentication

### DIFF
--- a/pages/login.jsx
+++ b/pages/login.jsx
@@ -16,7 +16,7 @@ const LoginPage = () => {
   async function onSubmit(e) {
     e.preventDefault();
     const body = {
-      username: e.currentTarget.email.value,
+      email: e.currentTarget.email.value,
       password: e.currentTarget.password.value,
     };
     const res = await fetch('/api/auth', {


### PR DESCRIPTION
Passport.js local strategy had ```usernameField: 'email'```. Therefore login was failing.