### PR TITLE
Add max age to session cookie

### DIFF
--- a/middlewares/session.js
+++ b/middlewares/session.js
@@ -12,5 +12,8 @@ export default function (req, res, next) {
   });
   return session({
     store: promisifyStore(mongoStore),
+    cookie: {
+      maxAge: 1000 * 60 * 60 * 24 * 14 // expires in 14 days
+    }
   })(req, res, next);
 }


### PR DESCRIPTION
# Summary 
- Add the cookie option to `next-session` instance and set the property `maxAge` to 14 days.