### PR TITLE
Return when 401 occurs for resetting password

### DIFF
--- a/pages/api/user/password/index.js
+++ b/pages/api/user/password/index.js
@@ -11,6 +11,7 @@ handler.put(async (req, res) => {
   const { oldPassword, newPassword } = req.body;
   if (!(await bcrypt.compare(oldPassword, req.user.password))) {
     res.status(401).send('The password you has entered is incorrect.');
+    return;
   }
   const password = await bcrypt.hash(newPassword, 10);
 


### PR DESCRIPTION
When the old password is not correct, i.e., 401 error will be thrown, the function should return.